### PR TITLE
test: add Cloudflare Vitest workflow coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,12 @@
     "": {
       "name": "cf-gait-workflow",
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.16.15",
         "@cloudflare/workers-types": "^4.20260611.1",
         "tsdown": "^0.22.2",
         "typescript": "catalog:",
         "vitest": "^4.1.8",
+        "wrangler": "catalog:",
       },
     },
     "playground": {
@@ -37,6 +39,8 @@
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.16.15", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.27.3", "miniflare": "4.20260611.0", "wrangler": "4.100.0", "zod": "3.25.76" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-R0kZhIm4uSxOeTWPHY9xYIFPGRBEHPzl/n9BbHZSY/gk0n16uDU7T1JZe372oTF+diXG1uVBWqiiRc7Hxstdow=="],
 
     "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260611.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA=="],
 
@@ -166,7 +170,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
@@ -255,6 +259,8 @@
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -396,7 +402,11 @@
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
-    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "vite/rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 

--- a/package.json
+++ b/package.json
@@ -30,12 +30,15 @@
   },
   "scripts": {
     "build": "tsdown",
-    "dev": "tsdown --watch"
+    "dev": "tsdown --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.15",
     "@cloudflare/workers-types": "^4.20260611.1",
     "tsdown": "^0.22.2",
     "typescript": "catalog:",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "wrangler": "catalog:"
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -6,7 +6,7 @@ export type GaitEventOptions = {
   timeout?: WorkflowSleepDuration | number;
 };
 
-type Defs = Record<"step:start" | "sleep:complete", void> &
+type Defs = Record<"step:start" | "sleep:complete", {}> &
   Record<"step:error" | "sleep:error" | "event:error", { error: unknown }> &
   Record<"step:complete" | "event:complete", { output: unknown }> & {
     "sleep:start": {

--- a/src/gait.ts
+++ b/src/gait.ts
@@ -192,38 +192,36 @@ async function sleep<This>(
   name: string,
   params: SleepParams,
 ): Promise<void> {
-  const ctx = {
-    step: { name, count: 1 },
-    attempt: 1,
-    config: {},
-  } satisfies WorkflowStepContext;
-  try {
-    this.emit("sleep:start", { params, ...ctx });
-    if (params instanceof Date) {
-      return await this.step
-        .sleepUntil(name, params)
-        .then(() => this.emit("sleep:complete", ctx));
-    } else if (typeof params === "number") {
-      return await this.step
-        .sleep(name, params)
-        .then(() => this.emit("sleep:complete", ctx));
-    } else if ("duration" in params) {
-      return await this.step
-        .sleep(name, params.duration)
-        .then(() => this.emit("sleep:complete", ctx));
-    } else {
-      return await this.step
-        .sleepUntil(name, params.timestamp)
-        .then(() => this.emit("sleep:complete", ctx));
+  await this.step.do(`gait:sleep`, async (ctx) => {
+    try {
+      this.emit("sleep:start", { params, ...ctx });
+
+      if (params instanceof Date) {
+        return await this.step
+          .sleepUntil(name, params)
+          .then(() => this.emit("sleep:complete", ctx));
+      } else if (typeof params === "number") {
+        return await this.step
+          .sleep(name, params)
+          .then(() => this.emit("sleep:complete", ctx));
+      } else if ("duration" in params) {
+        return await this.step
+          .sleep(name, params.duration)
+          .then(() => this.emit("sleep:complete", ctx));
+      } else {
+        return await this.step
+          .sleepUntil(name, params.timestamp)
+          .then(() => this.emit("sleep:complete", ctx));
+      }
+    } catch (error) {
+      this.emit("sleep:error", { error, ...ctx });
+      throw new NonRetryableWithRawError(
+        error,
+        `Gait sleep step "${name}" failed`,
+        "gait:sleep",
+      );
     }
-  } catch (error) {
-    this.emit("sleep:error", { error, ...ctx });
-    throw new NonRetryableWithRawError(
-      error,
-      `Gait sleep step "${name}" failed`,
-      "gait:sleep",
-    );
-  }
+  });
 }
 
 function event<This, T extends Rpc.Serializable<T>>(

--- a/src/gait.ts
+++ b/src/gait.ts
@@ -192,36 +192,38 @@ async function sleep<This>(
   name: string,
   params: SleepParams,
 ): Promise<void> {
-  await this.step.do(`gait:sleep`, async (ctx) => {
-    try {
-      this.emit("sleep:start", { params, ...ctx });
-
-      if (params instanceof Date) {
-        return await this.step
-          .sleepUntil(name, params)
-          .then(() => this.emit("sleep:complete", ctx));
-      } else if (typeof params === "number") {
-        return await this.step
-          .sleep(name, params)
-          .then(() => this.emit("sleep:complete", ctx));
-      } else if ("duration" in params) {
-        return await this.step
-          .sleep(name, params.duration)
-          .then(() => this.emit("sleep:complete", ctx));
-      } else {
-        return await this.step
-          .sleepUntil(name, params.timestamp)
-          .then(() => this.emit("sleep:complete", ctx));
-      }
-    } catch (error) {
-      this.emit("sleep:error", { error, ...ctx });
-      throw new NonRetryableWithRawError(
-        error,
-        `Gait sleep step "${name}" failed`,
-        "gait:sleep",
-      );
+  const ctx = {
+    step: { name, count: 1 },
+    attempt: 1,
+    config: {},
+  } satisfies WorkflowStepContext;
+  try {
+    this.emit("sleep:start", { params, ...ctx });
+    if (params instanceof Date) {
+      return await this.step
+        .sleepUntil(name, params)
+        .then(() => this.emit("sleep:complete", ctx));
+    } else if (typeof params === "number") {
+      return await this.step
+        .sleep(name, params)
+        .then(() => this.emit("sleep:complete", ctx));
+    } else if ("duration" in params) {
+      return await this.step
+        .sleep(name, params.duration)
+        .then(() => this.emit("sleep:complete", ctx));
+    } else {
+      return await this.step
+        .sleepUntil(name, params.timestamp)
+        .then(() => this.emit("sleep:complete", ctx));
     }
-  });
+  } catch (error) {
+    this.emit("sleep:error", { error, ...ctx });
+    throw new NonRetryableWithRawError(
+      error,
+      `Gait sleep step "${name}" failed`,
+      "gait:sleep",
+    );
+  }
 }
 
 function event<This, T extends Rpc.Serializable<T>>(

--- a/test/gait.test.ts
+++ b/test/gait.test.ts
@@ -1,0 +1,419 @@
+import {
+  env,
+  withExports,
+  type WorkflowEvent,
+  type WorkflowStep,
+  type WorkflowStepConfig,
+  type WorkflowStepContext,
+} from "cloudflare:workers";
+import { introspectWorkflowInstance } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGaitWorkflow,
+  defineGaitEmitter,
+  NonRetryableWithRawError,
+} from "../src";
+import type { Args, GaitEmitterWorkerEntrypoint } from "../src/events";
+
+type TestEnv = {
+  STEP_WORKFLOW: Workflow<{ mode?: string }>;
+  SLEEP_WORKFLOW: Workflow<{ mode: "number" | "duration" | "date" | "timestamp" }>;
+  EVENT_WORKFLOW: Workflow;
+};
+
+type Emitted = Args;
+
+const testEnv = env as TestEnv;
+
+const workflowEvent = {
+  payload: {},
+  timestamp: new Date(0),
+  instanceId: "instance",
+  workflowName: "workflow",
+} satisfies WorkflowEvent<unknown>;
+
+const defaultConfig = {
+  retries: { limit: 5, delay: 1_000, backoff: "exponential" as const },
+  timeout: "10 minutes" as WorkflowSleepDuration,
+};
+
+function createWorkflowStep(overrides: Partial<WorkflowStep> = {}) {
+  let count = 0;
+  const step: WorkflowStep = {
+    do: vi.fn(async (name: string, configOrCallback: unknown, callbackOrRollback?: unknown) => {
+      const hasConfig = typeof configOrCallback !== "function";
+      const config = hasConfig ? configOrCallback : defaultConfig;
+      const callback = hasConfig ? callbackOrRollback : configOrCallback;
+
+      return await (callback as (ctx: WorkflowStepContext) => Promise<unknown>)({
+        step: { name, count: ++count },
+        attempt: 1,
+        config: config as WorkflowStepConfig,
+      });
+    }),
+    sleep: vi.fn(async () => undefined),
+    sleepUntil: vi.fn(async () => undefined),
+    waitForEvent: vi.fn(async () => ({
+      payload: { approved: true },
+      timestamp: new Date(1),
+      type: "approval",
+    })),
+    ...overrides,
+  } as never;
+
+  return step;
+}
+
+function withGait<T>(
+  fn: (params: { events: Emitted[]; step: WorkflowStep }) => T,
+  step = createWorkflowStep(),
+) {
+  const events: Emitted[] = [];
+  const emitter: Pick<GaitEmitterWorkerEntrypoint, "emit"> = {
+    emit: (...args) => {
+      events.push(args);
+    },
+  };
+
+  return withExports({ GaitEmitter: emitter, CustomEmitter: emitter }, () =>
+    fn({ events, step }),
+  ) as T;
+}
+
+function createGait(step: WorkflowStep) {
+  return createGaitWorkflow({
+    event: workflowEvent,
+    step,
+  });
+}
+
+function eventNames(events: Emitted[]) {
+  return events.map(([event]) => event);
+}
+
+function expectTimestamp(ctx: Args[1]) {
+  expect(ctx.timestamp).toEqual(expect.any(Number));
+  expect(ctx.timestamp).toBeGreaterThan(0);
+}
+
+describe("defineGaitEmitter", () => {
+  it("passes through caller-provided timestamp without rewriting it", async () => {
+    const calls: Emitted[] = [];
+    const Emitter = defineGaitEmitter((...args) => {
+      calls.push(args);
+    });
+    const waitUntil = vi.fn((promise: Promise<unknown>) => promise);
+    const emitter = new Emitter({ waitUntil } as never, {} as never);
+
+    emitter.emit("step:start", {
+      step: { name: "x", count: 1 },
+      attempt: 1,
+      config: defaultConfig,
+      timestamp: 123,
+    });
+
+    await waitUntil.mock.results[0].value;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe("step:start");
+    expect(calls[0][1].timestamp).toBe(123);
+  });
+});
+
+describe("createGaitWorkflow", () => {
+  it("throws a clear non-retryable error when the emitter binding is missing", () => {
+    withExports({}, () => {
+      expect(() =>
+        createGaitWorkflow({
+          event: workflowEvent,
+          step: createWorkflowStep(),
+          binding: "MissingEmitter",
+        }),
+      ).toThrow('Gait emitter binding "MissingEmitter" was not found');
+    });
+  });
+
+  it("uses an explicit emitter binding", async () => {
+    await withGait(async ({ events, step }) => {
+      const gait = createGaitWorkflow({
+        event: workflowEvent,
+        step,
+        binding: "CustomEmitter",
+      });
+
+      await expect(gait.step("custom step", async () => "ok")).resolves.toBe("ok");
+
+      expect(eventNames(events)).toEqual(["step:start", "step:complete"]);
+      expect(events[0][1].step.name).toBe("custom step");
+      expectTimestamp(events[0][1]);
+    });
+  });
+});
+
+describe("gait.step", () => {
+  it("delegates to step.do and emits output on completion", async () => {
+    await withGait(async ({ events, step }) => {
+      const gait = createGait(step);
+
+      await expect(
+        gait.step("plain step", async (ctx) => ({
+          attempt: ctx.attempt,
+          name: ctx.step.name,
+        })),
+      ).resolves.toEqual({ attempt: 1, name: "plain step" });
+
+      expect(step.do).toHaveBeenCalledWith(
+        "plain step",
+        expect.any(Function),
+        undefined,
+      );
+      expect(eventNames(events)).toEqual(["step:start", "step:complete"]);
+      expectTimestamp(events[0][1]);
+      expect(events[1][1]).toMatchObject({
+        step: { name: "plain step" },
+        output: { attempt: 1, name: "plain step" },
+      });
+    });
+  });
+
+  it("preserves config and rollback options when delegating to step.do", async () => {
+    await withGait(async ({ events, step }) => {
+      const gait = createGait(step);
+      const config = { retries: { limit: 2, delay: 1 } };
+      const rollbackOptions = {
+        rollback: vi.fn(async () => undefined),
+      };
+
+      await expect(
+        gait.step("configured step", config, async () => "done", rollbackOptions),
+      ).resolves.toBe("done");
+
+      expect(step.do).toHaveBeenCalledWith(
+        "configured step",
+        config,
+        expect.any(Function),
+        rollbackOptions,
+      );
+      expect(events[0][1].config).toBe(config);
+      expect(events[1][1]).toMatchObject({ output: "done" });
+    });
+  });
+
+  it("emits step:error and rethrows callback failures", async () => {
+    const raw = new Error("step failed");
+
+    await withGait(async ({ events, step }) => {
+      const gait = createGait(step);
+
+      await expect(
+        gait.step("failing step", async () => {
+          throw raw;
+        }),
+      ).rejects.toBe(raw);
+
+      expect(eventNames(events)).toEqual(["step:start", "step:error"]);
+      expect(events[1][1]).toMatchObject({
+        step: { name: "failing step" },
+        error: raw,
+      });
+    });
+  });
+});
+
+describe("gait.sleep", () => {
+  it("delegates number and duration inputs to step.sleep", async () => {
+    await withGait(async ({ events, step }) => {
+      const gait = createGait(step);
+
+      await gait.sleep("number sleep", 10);
+      await gait.sleep("duration sleep", { duration: "1 second" });
+
+      expect(step.sleep).toHaveBeenNthCalledWith(1, "number sleep", 10);
+      expect(step.sleep).toHaveBeenNthCalledWith(2, "duration sleep", "1 second");
+      expect(eventNames(events)).toEqual([
+        "sleep:start",
+        "sleep:complete",
+        "sleep:start",
+        "sleep:complete",
+      ]);
+      expect(events[0][1]).toMatchObject({ params: 10 });
+      expect(events[2][1]).toMatchObject({ params: { duration: "1 second" } });
+    });
+  });
+
+  it("delegates Date and timestamp inputs to step.sleepUntil", async () => {
+    await withGait(async ({ events, step }) => {
+      const gait = createGait(step);
+      const date = new Date(Date.now() + 1_000);
+      const timestamp = Date.now() + 2_000;
+
+      await gait.sleep("date sleep", date);
+      await gait.sleep("timestamp sleep", { timestamp });
+
+      expect(step.sleepUntil).toHaveBeenNthCalledWith(1, "date sleep", date);
+      expect(step.sleepUntil).toHaveBeenNthCalledWith(
+        2,
+        "timestamp sleep",
+        timestamp,
+      );
+      expect(eventNames(events)).toEqual([
+        "sleep:start",
+        "sleep:complete",
+        "sleep:start",
+        "sleep:complete",
+      ]);
+      expect(events[0][1]).toMatchObject({ params: date });
+      expect(events[2][1]).toMatchObject({ params: { timestamp } });
+    });
+  });
+
+  it("wraps sleep failures with the raw error", async () => {
+    const raw = new Error("sleep failed");
+    const step = createWorkflowStep({
+      sleep: vi.fn(async () => {
+        throw raw;
+      }),
+    });
+
+    await withGait(async ({ events }) => {
+      const gait = createGait(step);
+
+      await expect(gait.sleep("bad sleep", 10)).rejects.toMatchObject({
+        raw,
+        message: 'Gait sleep step "bad sleep" failed',
+      });
+      await expect(gait.sleep("bad sleep", 10)).rejects.toBeInstanceOf(
+        NonRetryableWithRawError,
+      );
+
+      expect(eventNames(events)).toEqual([
+        "sleep:start",
+        "sleep:error",
+        "sleep:start",
+        "sleep:error",
+      ]);
+      expect(events[1][1]).toMatchObject({ error: raw });
+    }, step);
+  });
+});
+
+describe("gait.event", () => {
+  it("delegates to waitForEvent and emits output on completion", async () => {
+    await withGait(async ({ events, step }) => {
+      const gait = createGait(step);
+
+      await expect(
+        gait.event("approval", { type: "approval", timeout: "1 minute" }),
+      ).resolves.toMatchObject({
+        payload: { approved: true },
+        type: "approval",
+      });
+
+      expect(step.do).toHaveBeenCalledWith(
+        "approval",
+        { timeout: "1 minute" },
+        expect.any(Function),
+      );
+      expect(step.waitForEvent).toHaveBeenCalledWith("approval", {
+        type: "approval",
+        timeout: "1 minute",
+      });
+      expect(eventNames(events)).toEqual(["event:start", "event:complete"]);
+      expect(events[0][1]).toMatchObject({
+        options: { type: "approval", timeout: "1 minute" },
+      });
+      expect(events[1][1]).toMatchObject({
+        output: { payload: { approved: true }, type: "approval" },
+      });
+    });
+  });
+
+  it("wraps waitForEvent failures with the raw error", async () => {
+    const raw = new Error("event failed");
+    const step = createWorkflowStep({
+      waitForEvent: vi.fn(async () => {
+        throw raw;
+      }),
+    });
+
+    await withGait(async ({ events }) => {
+      const gait = createGait(step);
+
+      await expect(
+        gait.event("approval", { type: "approval", timeout: "1 minute" }),
+      ).rejects.toMatchObject({
+        raw,
+        message: 'Gait event step "approval" failed',
+      });
+      await expect(
+        gait.event("approval", { type: "approval", timeout: "1 minute" }),
+      ).rejects.toBeInstanceOf(NonRetryableWithRawError);
+
+      expect(eventNames(events)).toEqual([
+        "event:start",
+        "event:error",
+        "event:start",
+        "event:error",
+      ]);
+      expect(events[1][1]).toMatchObject({ error: raw });
+    }, step);
+  });
+});
+
+describe("Cloudflare Workflows integration", () => {
+  it("runs a real workflow that uses gait.step", async () => {
+    await using instance = await introspectWorkflowInstance(
+      testEnv.STEP_WORKFLOW,
+      "integration-step",
+    );
+
+    await testEnv.STEP_WORKFLOW.create({ id: "integration-step", params: {} });
+
+    await instance.waitForStatus("complete");
+    await expect(instance.getOutput()).resolves.toEqual({
+      first: { attempt: 1, name: "plain step" },
+      configured: { ok: true },
+    });
+  });
+
+  it("runs a real workflow that uses gait.sleep", async () => {
+    await using instance = await introspectWorkflowInstance(
+      testEnv.SLEEP_WORKFLOW,
+      "integration-sleep",
+    );
+
+    await instance.modify(async (m) => {
+      await m.disableSleeps();
+    });
+
+    await testEnv.SLEEP_WORKFLOW.create({
+      id: "integration-sleep",
+      params: { mode: "timestamp" },
+    });
+
+    await instance.waitForStatus("complete");
+    await expect(instance.getOutput()).resolves.toEqual({ slept: "timestamp" });
+  });
+
+  it("runs a real workflow that uses gait.event", async () => {
+    await using instance = await introspectWorkflowInstance(
+      testEnv.EVENT_WORKFLOW,
+      "integration-event",
+    );
+
+    await instance.modify(async (m) => {
+      await m.mockEvent({
+        type: "approval",
+        payload: { approved: true },
+      });
+    });
+
+    await testEnv.EVENT_WORKFLOW.create({ id: "integration-event" });
+
+    await instance.waitForStatus("complete");
+    await expect(instance.getOutput()).resolves.toEqual({
+      payload: { approved: true },
+      type: "approval",
+    });
+  });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "@cloudflare/workers-types",
+      "@cloudflare/vitest-pool-workers/types",
+      "vitest/globals",
+    ],
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"],
+}

--- a/test/worker.ts
+++ b/test/worker.ts
@@ -3,30 +3,10 @@ import {
   defineGaitEmitter,
   defineGaitWorkflowEntrypoint,
 } from "../src";
-import type { Args } from "../src/events";
 
-export type RecordedEvent = {
-  event: Args[0];
-  ctx: Args[1];
-};
+export const GaitEmitter = defineGaitEmitter(() => undefined);
 
-const events: RecordedEvent[] = [];
-
-export function clearEvents(): void {
-  events.length = 0;
-}
-
-export function getEvents(): RecordedEvent[] {
-  return structuredClone(events);
-}
-
-export const GaitEmitter = defineGaitEmitter((event, ctx) => {
-  events.push({ event, ctx } as RecordedEvent);
-});
-
-export const CustomEmitter = defineGaitEmitter((event, ctx) => {
-  events.push({ event, ctx } as RecordedEvent);
-});
+export const CustomEmitter = defineGaitEmitter(() => undefined);
 
 export const StepWorkflow = defineGaitWorkflowEntrypoint(
   async (event, gait) => {

--- a/test/worker.ts
+++ b/test/worker.ts
@@ -1,0 +1,118 @@
+import {
+  createGaitWorkflow,
+  defineGaitEmitter,
+  defineGaitWorkflowEntrypoint,
+} from "../src";
+import type { Args } from "../src/events";
+
+export type RecordedEvent = {
+  event: Args[0];
+  ctx: Args[1];
+};
+
+const events: RecordedEvent[] = [];
+
+export function clearEvents(): void {
+  events.length = 0;
+}
+
+export function getEvents(): RecordedEvent[] {
+  return structuredClone(events);
+}
+
+export const GaitEmitter = defineGaitEmitter((event, ctx) => {
+  events.push({ event, ctx } as RecordedEvent);
+});
+
+export const CustomEmitter = defineGaitEmitter((event, ctx) => {
+  events.push({ event, ctx } as RecordedEvent);
+});
+
+export const StepWorkflow = defineGaitWorkflowEntrypoint(
+  async (event, gait) => {
+    const mode = (event.payload as { mode?: string }).mode;
+
+    if (mode === "missing-emitter") {
+      createGaitWorkflow({
+        event,
+        step: {
+          do: async () => undefined,
+        } as never,
+        binding: "MissingEmitter",
+      });
+    }
+
+    const first = await gait.step("plain step", async (ctx) => ({
+      attempt: ctx.attempt,
+      name: ctx.step.name,
+    }));
+
+    const configured = await gait.step(
+      "configured step",
+      { retries: { limit: 2, delay: 1 } },
+      async () => {
+        if (mode === "step-error") {
+          throw new Error("step failed");
+        }
+
+        return { ok: true };
+      },
+    );
+
+    return { first, configured };
+  },
+);
+
+export const CustomBindingWorkflow = defineGaitWorkflowEntrypoint(
+  "CustomEmitter",
+  async (_event, gait) => {
+    return await gait.step("custom binding step", async () => "custom");
+  },
+);
+
+export const SleepWorkflow = defineGaitWorkflowEntrypoint(
+  async (event, gait) => {
+    const mode = (event.payload as { mode?: string }).mode;
+
+    if (mode === "number") {
+      await gait.sleep("number sleep", 10);
+    } else if (mode === "duration") {
+      await gait.sleep("duration sleep", { duration: "1 second" });
+    } else if (mode === "date") {
+      await gait.sleep("date sleep", new Date(Date.now() + 1_000));
+    } else {
+      await gait.sleep("timestamp sleep", { timestamp: Date.now() + 1_000 });
+    }
+
+    return { slept: mode };
+  },
+);
+
+export const EventWorkflow = defineGaitWorkflowEntrypoint(
+  async (_event, gait) => {
+    const result = await gait.event("approval", {
+      type: "approval",
+      timeout: "1 minute",
+    });
+
+    return {
+      payload: result.payload,
+      type: result.type,
+    };
+  },
+);
+
+export const EventTimeoutWorkflow = defineGaitWorkflowEntrypoint(
+  async (_event, gait) => {
+    await gait.event("approval timeout", {
+      type: "approval-timeout",
+      timeout: "1 minute",
+    });
+  },
+);
+
+export default {
+  fetch() {
+    return Response.json({ ok: true });
+  },
+};

--- a/test/wrangler.jsonc
+++ b/test/wrangler.jsonc
@@ -1,0 +1,33 @@
+{
+  "$schema": "../node_modules/wrangler/config-schema.json",
+  "name": "cf-gait-workflow-test",
+  "main": "worker.ts",
+  "compatibility_date": "2026-06-11",
+  "workflows": [
+    {
+      "name": "step-workflow",
+      "binding": "STEP_WORKFLOW",
+      "class_name": "StepWorkflow",
+    },
+    {
+      "name": "custom-binding-workflow",
+      "binding": "CUSTOM_BINDING_WORKFLOW",
+      "class_name": "CustomBindingWorkflow",
+    },
+    {
+      "name": "sleep-workflow",
+      "binding": "SLEEP_WORKFLOW",
+      "class_name": "SleepWorkflow",
+    },
+    {
+      "name": "event-workflow",
+      "binding": "EVENT_WORKFLOW",
+      "class_name": "EventWorkflow",
+    },
+    {
+      "name": "event-timeout-workflow",
+      "binding": "EVENT_TIMEOUT_WORKFLOW",
+      "class_name": "EventTimeoutWorkflow",
+    },
+  ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,6 @@
   "references": [
     { "path": "./src/tsconfig.json" },
     { "path": "./playground/tsconfig.json" },
+    { "path": "./test/tsconfig.json" },
   ],
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      wrangler: { configPath: "./test/wrangler.jsonc" },
+    }),
+  ],
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- add Cloudflare Workers Vitest integration using `@cloudflare/vitest-pool-workers`
- add comprehensive gait coverage for emitter, workflow creation, `gait.step`, `gait.sleep`, and `gait.event`
- add a test-only Worker and `test/wrangler.jsonc` fixture for real Workflow integration checks
- adjust empty event payload typing from `void` to `{}` so lifecycle event contexts are constructible
- emit sleep lifecycle events around the native sleep/sleepUntil operation instead of an extra `gait:sleep` step wrapper

## Validation

- `bunx tsc -b`
- `bun run build`
- `bun run test` (14 passed)

No linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite validating step execution, sleep operations, event handling, and error scenarios.
  * Implemented Cloudflare Workflows integration tests to verify expected behavior.

* **Chores**
  * Added testing framework configuration and infrastructure setup.
  * Configured test runner and worker environment for automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->